### PR TITLE
feat: Add 2FA setup for user accounts

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -97,3 +97,4 @@ export const dailyFinancialCheck = functions.pubsub
 export * from "./crypto";
 export * from "./stocks";
 export * from "./notifications";
+export * from "./security";

--- a/functions/src/security.ts
+++ b/functions/src/security.ts
@@ -1,0 +1,76 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import { generateTotpSecret, verifyTOTP } from "./totp";
+
+const db = admin.firestore();
+const ISSUER = "Finwise AI"; // The name of the app
+
+/**
+ * Generates a new TOTP secret for a user and returns an otpauth:// URI.
+ * The secret is stored in a private subcollection of the user's document.
+ */
+export const generate2faSecret = functions.https.onCall(async (data, context) => {
+    if (!context.auth) {
+        throw new functions.https.HttpsError("unauthenticated", "The function must be called while authenticated.");
+    }
+    const uid = context.auth.uid;
+    const userEmail = context.auth.token.email || "user";
+
+    const secret = generateTotpSecret();
+    const uri = `otpauth://totp/${ISSUER}:${userEmail}?secret=${secret}&issuer=${ISSUER}&algorithm=SHA1&digits=6&period=30`;
+
+    // Store the secret securely. A subcollection on the user doc is a good choice.
+    const secretRef = db.collection('users').doc(uid).collection('private').doc('security');
+
+    try {
+        await secretRef.set({ totpSecret: secret }, { merge: true });
+        return { uri, secret }; // Return both for manual entry
+    } catch (error) {
+        functions.logger.error(`Failed to save TOTP secret for user ${uid}:`, error);
+        throw new functions.https.HttpsError("internal", "Could not save the secret.");
+    }
+});
+
+/**
+ * Verifies a TOTP token and enables 2FA for the user.
+ */
+export const verifyAndEnable2fa = functions.https.onCall(async (data: { token: string }, context) => {
+    if (!context.auth) {
+        throw new functions.https.HttpsError("unauthenticated", "The function must be called while authenticated.");
+    }
+    const uid = context.auth.uid;
+    const token = data.token;
+
+    if (!token || typeof token !== 'string' || token.length !== 6) {
+        throw new functions.https.HttpsError("invalid-argument", "A valid 6-digit token is required.");
+    }
+
+    const secretRef = db.collection('users').doc(uid).collection('private').doc('security');
+    const userRef = db.collection('users').doc(uid);
+
+    try {
+        const secretDoc = await secretRef.get();
+        if (!secretDoc.exists || !secretDoc.data()?.totpSecret) {
+            throw new functions.https.HttpsError("not-found", "No 2FA secret found for this user. Please start over.");
+        }
+        const secret = secretDoc.data()!.totpSecret;
+
+        const isValid = verifyTOTP(secret, token);
+
+        if (!isValid) {
+            throw new functions.https.HttpsError("permission-denied", "The token is invalid or has expired.");
+        }
+
+        // Token is valid, enable 2FA for the user
+        await userRef.update({ is2faEnabled: true });
+
+        return { success: true, message: "2FA has been successfully enabled." };
+
+    } catch (error) {
+        functions.logger.error(`Failed to verify token for user ${uid}:`, error);
+        if (error instanceof functions.https.HttpsError) {
+            throw error;
+        }
+        throw new functions.https.HttpsError("internal", "An error occurred during token verification.");
+    }
+});

--- a/functions/src/totp.ts
+++ b/functions/src/totp.ts
@@ -1,0 +1,73 @@
+import * as crypto from 'crypto';
+
+const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+function base32Encode(buffer: Buffer): string {
+    let bits = '';
+    for (let i = 0; i < buffer.length; i++) {
+        bits += buffer[i].toString(2).padStart(8, '0');
+    }
+
+    let base32 = '';
+    for (let i = 0; i < bits.length; i += 5) {
+        const chunk = bits.slice(i, i + 5);
+        if (chunk.length < 5) {
+            base32 += alphabet[parseInt(chunk.padEnd(5, '0'), 2)];
+        } else {
+            base32 += alphabet[parseInt(chunk, 2)];
+        }
+    }
+
+    // Add padding
+    const padding = (8 - (base32.length % 8)) % 8;
+    return base32 + '='.repeat(padding);
+}
+
+
+function base32ToBytes(b32: string): Uint8Array {
+  const clean = b32.replace(/=+$/,'').toUpperCase().replace(/\s+/g,'');
+  let bits = '';
+  for (const c of clean) {
+    const val = alphabet.indexOf(c);
+    if (val < 0) throw new Error('Invalid base32');
+    bits += val.toString(2).padStart(5, '0');
+  }
+  const bytes: number[] = [];
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.slice(i, i+8), 2));
+  }
+  return new Uint8Array(bytes);
+}
+
+export function generateTotpSecret(): string {
+    const buffer = crypto.randomBytes(20); // 160 bits is a common secret length
+    return base32Encode(buffer);
+}
+
+export function generateTOTP(secretBase32: string, time = Date.now(), step = 30, digits = 6): string {
+  const counter = Math.floor(time / 1000 / step);
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(BigInt(counter));
+
+  const key = Buffer.from(base32ToBytes(secretBase32));
+  const hmac = crypto.createHmac('sha1', key).update(buf).digest();
+
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+
+  const mod = 10 ** digits;
+  return (code % mod).toString().padStart(digits, '0');
+}
+
+export function verifyTOTP(secretBase32: string, token: string, window = 1, step = 30, digits = 6): boolean {
+  const now = Date.now();
+  for (let w = -window; w <= window; w++) {
+    const t = now + w * step * 1000;
+    if (generateTOTP(secretBase32, t, step, digits) === token) return true;
+  }
+  return false;
+}

--- a/package.json
+++ b/package.json
@@ -63,11 +63,14 @@
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "use-debounce": "^10.0.1",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "speakeasy": "^2.0.0",
+    "qrcode.react": "^3.1.0"
   },
   "devDependencies": {
     "@tailwindcss/container-queries": "^0.1.0",
     "@types/crypto-js": "^4.2.2",
+    "@types/speakeasy": "^2.0.10",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/components/finwise/profile-screen.tsx
+++ b/src/components/finwise/profile-screen.tsx
@@ -4,9 +4,10 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
-import { ChevronRight, LogIn, LogOut, Upload, Loader, Users } from "lucide-react";
+import { ChevronRight, LogIn, LogOut, Upload, Loader, Users, ShieldCheck } from "lucide-react";
 import type { User } from 'firebase/auth';
 import Link from 'next/link';
+import { TwoFactorAuthSetupDialog } from './two-factor-auth-setup-dialog';
 import { useToast } from "@/hooks/use-toast";
 import { signOut, linkToGoogle } from "@/lib/auth";
 import { useState, useRef, ChangeEvent } from "react";
@@ -25,6 +26,7 @@ export function ProfileScreen({ user, offline, setOffline = () => {} }: ProfileS
   const { toast } = useToast();
   const [isLinking, setIsLinking] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
+  const [is2faDialogOpen, setIs2faDialogOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   
   if (!user) {
@@ -198,6 +200,21 @@ export function ProfileScreen({ user, offline, setOffline = () => {} }: ProfileS
 
       <Card>
         <CardHeader>
+          <CardTitle>セキュリティ</CardTitle>
+          <CardDescription>
+            2段階認証を設定してアカウントを保護します。
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+            <Button onClick={() => setIs2faDialogOpen(true)}>
+              <ShieldCheck className="mr-2 h-4 w-4" />
+              2段階認証を設定
+            </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
           <CardTitle className="font-headline text-lg">データ管理</CardTitle>
           <CardDescription>取引データのインポート・エクスポート</CardDescription>
         </CardHeader>
@@ -211,6 +228,8 @@ export function ProfileScreen({ user, offline, setOffline = () => {} }: ProfileS
           <Button variant="destructive">全データを削除</Button>
         </CardContent>
       </Card>
+
+      <TwoFactorAuthSetupDialog open={is2faDialogOpen} onOpenChange={setIs2faDialogOpen} />
     </div>
   );
 }

--- a/src/components/finwise/two-factor-auth-setup-dialog.tsx
+++ b/src/components/finwise/two-factor-auth-setup-dialog.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const functions = getFunctions();
+const generate2faSecretFn = httpsCallable(functions, 'generate2faSecret');
+const verifyAndEnable2faFn = httpsCallable(functions, 'verifyAndEnable2fa');
+
+interface TwoFactorAuthSetupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function TwoFactorAuthSetupDialog({ open, onOpenChange }: TwoFactorAuthSetupDialogProps) {
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(true);
+  const [secret, setSecret] = useState('');
+  const [uri, setUri] = useState('');
+  const [verificationCode, setVerificationCode] = useState('');
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      const generateSecret = async () => {
+        setIsLoading(true);
+        try {
+          const result = await generate2faSecretFn();
+          const data = result.data as { secret: string; uri: string };
+          setSecret(data.secret);
+          setUri(data.uri);
+        } catch (e) {
+          console.error(e);
+          toast({ title: "秘密鍵の生成に失敗しました", variant: "destructive" });
+          onOpenChange(false);
+        } finally {
+          setIsLoading(false);
+        }
+      };
+      generateSecret();
+    }
+  }, [open, onOpenChange, toast]);
+
+  const handleVerify = async () => {
+    if (verificationCode.length !== 6) {
+      toast({ title: "6桁のコードを入力してください", variant: "destructive" });
+      return;
+    }
+    setIsVerifying(true);
+    try {
+      await verifyAndEnable2faFn({ token: verificationCode });
+      toast({ title: "2段階認証が有効になりました", description: "次回ログイン時から認証コードの入力が必要になります。" });
+      onOpenChange(false);
+    } catch (e: any) {
+      console.error(e);
+      toast({ title: "認証に失敗しました", description: e.message || "コードが正しくないか、有効期限が切れています。", variant: "destructive" });
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>2段階認証を設定する</DialogTitle>
+          <DialogDescription>
+            認証アプリ（Google Authenticatorなど）を使って設定してください。
+          </DialogDescription>
+        </DialogHeader>
+        {isLoading ? (
+            <div className="space-y-4 py-4">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-4 w-full" />
+            </div>
+        ) : (
+            <div className="space-y-4 py-4">
+                <p className="text-sm text-muted-foreground">
+                    1. 認証アプリを開き、新しいアカウントを追加します。
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    2. QRコードをスキャンする代わりに、「セットアップキー」または「手動入力」を選択し、以下のキーをコピーして貼り付けます。
+                </p>
+                <div className="p-2 bg-muted rounded-md">
+                    <Label htmlFor="secret-key">セットアップキー</Label>
+                    <Input id="secret-key" readOnly value={secret} className="font-mono mt-1" />
+                </div>
+                 <p className="text-sm text-muted-foreground">
+                    3. アプリに表示された6桁のコードを以下に入力して、設定を完了します。
+                </p>
+                <div>
+                    <Label htmlFor="code">認証コード</Label>
+                    <Input id="code" value={verificationCode} onChange={(e) => setVerificationCode(e.target.value)} maxLength={6} placeholder="123456" />
+                </div>
+            </div>
+        )}
+        <DialogFooter>
+          <Button onClick={handleVerify} disabled={isLoading || isVerifying}>
+            {isVerifying ? '検証中...' : '検証して有効化'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Implements the user-facing flow for enabling TOTP 2FA.

- Adds backend functions to generate and store a TOTP secret, and to verify a token to enable 2FA. The logic is implemented without external libraries, using the built-in crypto module.
- Adds a new dialog component to the frontend to guide the user through the setup process, providing the secret for manual entry.
- Adds a "Security" section to the profile screen to launch the 2FA setup dialog.