### PR TITLE
feat: Add showErrorToast for improved error handling

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -192,4 +192,36 @@ function useToast() {
   }
 }
 
-export { useToast, toast }
+function showErrorToast(error: any) {
+  console.error("Displaying error toast:", error);
+
+  let title = "エラーが発生しました";
+  let description = "不明なエラーです。時間をおいて再度お試しください。";
+
+  if (error instanceof Error) {
+    // Handle generic network errors
+    if (error.message.toLowerCase().includes('failed to fetch') || error.message.toLowerCase().includes('network')) {
+      title = "ネットワークエラー";
+      description = "ネットワーク接続が不安定です。接続を確認して再度お試しください。";
+    }
+    // Handle AI-related timeouts or lack of response
+    else if (error.message.toLowerCase().includes('timeout') || error.message.toLowerCase().includes('no response')) {
+      title = "AIの応答エラー";
+      description = "AIからの応答がありませんでした。時間を置いて再度お試しください。";
+    }
+    // For other generic errors, use their message
+    else {
+      description = error.message;
+    }
+  } else if (typeof error === 'string') {
+    description = error;
+  }
+
+  toast({
+    variant: "destructive",
+    title: title,
+    description: description,
+  })
+}
+
+export { useToast, toast, showErrorToast }


### PR DESCRIPTION
Introduces a new `showErrorToast` function in the `useToast` hook to provide a centralized and user-friendly way to display error messages.

This new utility function inspects the error provided and shows a destructive-variant toast with a context-specific message in Japanese. It handles generic errors as well as specific cases like network failures or AI timeouts, as requested in the project proposal.