### PR TITLE
feat: Implement offline support for transactions

### DIFF
--- a/src/hooks/use-online-status.ts
+++ b/src/hooks/use-online-status.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export function useOnlineStatus() {
+  const [isOnline, setIsOnline] = useState(true);
+
+  useEffect(() => {
+    // Check the initial status
+    if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
+        setIsOnline(navigator.onLine);
+    }
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}


### PR DESCRIPTION
This commit introduces offline capabilities for transaction creation, as outlined in the "Robust Error Handling and Improved Offline Experience" section of the project proposal.

- A new `useOnlineStatus` hook is added to detect network connectivity.
- The transaction form now saves new transactions to `localStorageっh` when the user is offline.
- A synchronization mechanism in `AppContainer` automatically submits these pending transactions to Firestore when the application comes back online.