### PR TITLE
feat: Update firestore rules to a minimal secure version

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,54 +1,29 @@
 rules_version = '2';
-
 service cloud.firestore {
-  match /databases/{database}/documents {
-
-    // Helper function to get the user's familyId from their profile
-    function getUserFamilyId(userId) {
-      return get(/databases/$(database)/documents/users/$(userId)).data.familyId;
+  match /databases/{db}/documents {
+    function isMember(fid) {
+      return request.auth != null &&
+        get(/databases/$(db)/documents/families/$(fid)).data.members[request.auth.uid] != null;
     }
+    match /families/{fid} {
+      allow read: if isMember(fid);
+      allow write: if isMember(fid);
 
-    // Users can only read/write their own profile.
-    match /users/{userId} {
-      allow read, update, delete: if request.auth.uid == userId;
-      // Anyone can create their own user profile (e.g., on signup).
-      allow create: if request.auth.uid == userId;
-    }
-
-    // Rules for the new 'families' collection
-    match /families/{familyId} {
-      // A user can read a family document if their UID is in the `members` array.
-      allow read: if request.auth.uid in resource.data.members;
-
-      // For writes (update, delete), we might want more granular control
-      // e.g., only an 'owner' or 'admin' can change the family name or remove members.
-      // For now, we'll allow any member to update.
-      allow update: if request.auth.uid in resource.data.members;
-
-      // Only authenticated users can create a new family.
-      // The creating user must be the first member.
-      allow create: if request.auth != null && request.auth.uid in request.resource.data.members;
-
-      // Nobody can just delete a family for now to prevent accidental data loss.
-      allow delete: if false;
-
-      // Rules for all subcollections under a family (transactions, budgets, goals, etc.)
-      match /{subcollection}/{docId} {
-        // Allow creation if the user is part of the family.
-        // The document must correctly list the creator's UID.
-        allow create: if getUserFamilyId(request.auth.uid) == familyId
-                      && request.resource.data.createdBy == request.auth.uid;
-
-        // Allow read if the document is shared and user is in the family,
-        // OR if the document is personal and the user is the creator.
-        allow read: if getUserFamilyId(request.auth.uid) == familyId
-                    && (request.resource.data.scope == 'shared' || request.resource.data.createdBy == request.auth.uid);
-
-        // Allow update/delete only if the user is the original creator.
-        // This is the safest default. We can relax this for shared items later if needed.
-        allow update, delete: if getUserFamilyId(request.auth.uid) == familyId
-                              && resource.data.createdBy == request.auth.uid;
+      match /transactions/{tid} {
+        allow read, create: if isMember(fid);
+        allow update, delete: if isMember(fid) && request.resource.data.familyId == fid;
+        // 型チェック（最小）
+        function ok() {
+          return request.resource.data.keys().hasAll(["amount","date","category"])
+            && request.resource.data.amount is number
+            && request.resource.data.date is timestamp
+            && request.resource.data.category is string;
+        }
+        allow create, update: if isMember(fid) && ok();
       }
+
+      match /budgets/{bid} { allow read, write: if isMember(fid); }
+      match /subscriptions/{sid} { allow read, write: if isMember(fid); }
     }
   }
 }


### PR DESCRIPTION
This commit replaces the existing Firestore security rules with a new, simpler set of rules provided for the MVP.

The new rules are based on a 'family' data model, where user access is determined by their membership in a family group.

Key changes:
- A new `isMember(fid)` function checks if an authenticated user is a member of a given family.
- Access to the `families` collection and its subcollections (`transactions`, `budgets`, `subscriptions`) is now governed by this family membership check.
- Basic type validation has been added for creating and updating transactions.