### PR TITLE
feat: Implement manual subscription detection and tagging

### DIFF
--- a/src/ai/flows/detect-subscriptions.ts
+++ b/src/ai/flows/detect-subscriptions.ts
@@ -25,6 +25,7 @@ const SubscriptionSchema = z.object({
   wasteScore: z.number().min(0).max(1).describe('A score from 0 to 1 indicating how likely this subscription is to be wasteful, based on usage patterns or redundancy. 1.0 means very likely wasteful.'),
   nextDate: z.string().describe('The estimated next payment date in YYYY-MM-DD format.'),
   suggestion: z.string().describe('A concrete, actionable suggestion for the user if there is potential for optimization. E.g., "Consider switching to an annual plan to save money." or "You have multiple video streaming services." If no specific suggestion, provide a general summary.'),
+  transactionIds: z.array(z.string()).describe('An array of transaction IDs that belong to this subscription.'),
 });
 
 const DetectSubscriptionsOutputSchema = z.object({
@@ -59,6 +60,7 @@ prompt: `あなたは賢い家計簿アシスタントです。以下の取引�
   - 同じカテゴリに複数のサブスクがある場合は、統合を提案します。（例：「動画配信サービスに複数登録しています。一つに絞ると節約できます。」）
   - 特に提案がない場合は、そのサービスに関する一般的な情報を提供します。（例：「定額で映画やドラマが見放題のサービスです。」）
   - 提案は、ユーザーが次に行うべきアクションが分かるように、具体的で短い一文にしてください。
+- **重要**: 特定した各サブスクリプションについて、その判断の根拠となった取引の`id`をすべて`transactionIds`という配列に含めてください。
 
 結果を構造化されたJSONオブジェクトとして日本語で返してください。`,
 });

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,11 +1,106 @@
 'use server';
 
 import { receiptOcr, ReceiptOcrInput, ReceiptOcrOutput } from "@/ai/flows/receipt-ocr";
+import { detectSubscriptions } from "@/ai/flows/detect-subscriptions";
+import { getFirebaseAdminApp } from "@/lib/firebase-admin";
+import { firestore } from 'firebase-admin';
 
+// For processReceipt
 interface ActionResult {
   success: boolean;
   data?: ReceiptOcrOutput;
   error?: string;
+}
+
+// For scanAndTagSubscriptions
+interface ScanAndTagResult {
+    success: boolean;
+    taggedCount?: number;
+    error?: string;
+}
+
+// Helper function to serialize data with Timestamps for AI flow
+const serializeDataForAI = (data: any): any => {
+    if (!data) return data;
+    if (data instanceof firestore.Timestamp) {
+        return data.toDate().toISOString();
+    }
+    if (Array.isArray(data)) {
+        return data.map(serializeDataForAI);
+    }
+    if (typeof data === 'object') {
+        const newObj: { [key: string]: any } = {};
+        for (const key in data) {
+            if (Object.prototype.hasOwnProperty.call(data, key)) {
+                newObj[key] = serializeDataForAI(data[key]);
+            }
+        }
+        return newObj;
+    }
+    return data;
+};
+
+export async function scanAndTagSubscriptions(familyId: string): Promise<ScanAndTagResult> {
+    if (!familyId) {
+        return { success: false, error: "Family ID is required." };
+    }
+
+    try {
+        getFirebaseAdminApp(); // Ensure admin app is initialized
+        const db = firestore();
+
+        // 1. Fetch recent transactions for the family
+        const oneYearAgo = new Date();
+        oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+        const transactionsSnapshot = await db.collection(`families/${familyId}/transactions`)
+            .where('bookedAt', '>=', oneYearAgo)
+            .get();
+
+        if (transactionsSnapshot.empty) {
+            return { success: true, taggedCount: 0 };
+        }
+
+        const transactions = transactionsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+
+        // 2. Call the AI flow
+        const serializedTransactions = serializeDataForAI(transactions);
+        const detectionResult = await detectSubscriptions({ transactions: serializedTransactions });
+
+        if (!detectionResult.subscriptions || detectionResult.subscriptions.length === 0) {
+            return { success: true, taggedCount: 0 };
+        }
+
+        // 3. Process results and tag transactions
+        let taggedCount = 0;
+        const batch = db.batch();
+
+        for (const subscription of detectionResult.subscriptions) {
+            if (subscription.transactionIds) {
+                for (const txId of subscription.transactionIds) {
+                    // Check if the transaction exists in our fetched list
+                    const txExists = transactions.some(t => t.id === txId);
+                    if (txExists) {
+                        const txRef = db.doc(`families/${familyId}/transactions/${txId}`);
+                        batch.update(txRef, {
+                            tags: firestore.FieldValue.arrayUnion('subscription')
+                        });
+                        taggedCount++;
+                    }
+                }
+            }
+        }
+
+        if (taggedCount > 0) {
+            await batch.commit();
+        }
+
+        return { success: true, taggedCount };
+
+    } catch (e: any) {
+        console.error("scanAndTagSubscriptions failed:", e);
+        return { success: false, error: "サブスクリプションのスキャン中にエラーが発生しました。" };
+    }
 }
 
 export async function processReceipt(input: ReceiptOcrInput): Promise<ActionResult> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface Transaction {
   scope?: 'personal' | 'shared';
   createdBy?: string;
   taxTag?: string;
+  tags?: string[];
   plaidTransactionId?: string;
   plaidAccountId?: string;
 }


### PR DESCRIPTION
This commit introduces the MVP feature for subscription detection, as outlined in the project document. This includes a manual scan button that finds and tags recurring transactions as subscriptions.

Key changes:
- The `Transaction` type in `src/lib/types.ts` now includes an optional `tags` array.
- The `detect-subscriptions` AI flow has been updated to return the source transaction IDs for each subscription it identifies.
- A new server action, `scanAndTagSubscriptions`, has been created. This action fetches transactions, runs the AI detection flow, and then uses a batch write to update the identified transaction documents in Firestore, adding a 'subscription' tag.
- The subscriptions page at `/app/subscriptions` has been refactored. It now features a 'Scan' button that triggers the server action. The page displays transactions that have been tagged as subscriptions from the database, rather than displaying one-off results from an AI call.